### PR TITLE
feat: add maketarget for bash and zsh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 _build/
 _build
+bin/
 _deps*/
 _deps
 cmd/juju/juju
@@ -38,3 +39,4 @@ dqlite-deps.tar.bz2
 .envrc
 .direnv/
 .codex
+.juju

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ endef
 # compiled
 define BUILD_CLIENT_TARGETS
 	$(call tool_platform_paths,juju,${CLIENT_PACKAGE_PLATFORMS}) \
+	$(call tool_platform_paths,juju-complete,${CLIENT_PACKAGE_PLATFORMS}) \
 	$(call tool_platform_paths,juju-metadata,${CLIENT_PACKAGE_PLATFORMS})
 endef
 
@@ -152,6 +153,7 @@ endef
 # install is run.
 define INSTALL_TARGETS
 	juju \
+	juju-complete \
 	jujuc \
 	jujud \
 	containeragent \
@@ -305,6 +307,44 @@ juju:
 ## juju: Install juju without updating dependencies
 	${run_go_install}
 
+.PHONY: juju-complete
+juju-complete: PACKAGE = github.com/juju/juju/cmd/juju-complete
+juju-complete:
+## juju-complete: Install juju-complete without updating dependencies
+	${run_go_install}
+
+.PHONY: enable-zsh-completion
+enable-zsh-completion: juju juju-complete
+## enable-zsh-completion: Install local zsh completion for this checkout
+	@mkdir -p "$${JUJU_DATA:-$(PROJECT_DIR)/.juju}/zsh/site-functions"
+	@printf '%s\n' \
+		'#compdef juju' \
+		'_juju() {' \
+		'    local -a comps' \
+		'    comps=($${(f)"$$(juju-complete --shell zsh --position "$$CURRENT" -- $${words[@]})"})' \
+		'    _describe '\''juju'\'' comps' \
+		'}' \
+		'if (( $$+functions[compdef] )); then' \
+		'    compdef _juju juju' \
+		'fi' \
+		> "$${JUJU_DATA:-$(PROJECT_DIR)/.juju}/zsh/site-functions/_juju"
+	@echo "Zsh completion installed at $${JUJU_DATA:-$(PROJECT_DIR)/.juju}/zsh/site-functions/_juju"
+	@echo "Run: fpath=($${JUJU_DATA:-$(PROJECT_DIR)/.juju}/zsh/site-functions \$$fpath) && autoload -Uz compinit && compinit"
+
+.PHONY: enable-bash-completion
+enable-bash-completion: juju juju-complete
+## enable-bash-completion: Install local bash completion for this checkout
+	@mkdir -p "$${JUJU_DATA:-$(PROJECT_DIR)/.juju}/bash_completion.d"
+	@printf '%s\n' \
+		'_juju() {' \
+		'    local IFS=$$'"'"'\n'"'"'' \
+		'    COMPREPLY=($$(juju-complete --shell bash --position "$$COMP_CWORD" -- "$${COMP_WORDS[@]}"))' \
+		'}' \
+		'complete -F _juju juju' \
+		> "$${JUJU_DATA:-$(PROJECT_DIR)/.juju}/bash_completion.d/juju"
+	@echo "Bash completion installed at $${JUJU_DATA:-$(PROJECT_DIR)/.juju}/bash_completion.d/juju"
+	@echo "Run: source $${JUJU_DATA:-$(PROJECT_DIR)/.juju}/bash_completion.d/juju"
+
 .PHONY: jujuc
 jujuc: PACKAGE = github.com/juju/juju/cmd/jujuc
 jujuc:
@@ -399,6 +439,11 @@ ${BUILD_DIR}/%/bin/containeragent: phony_explicit
 ${BUILD_DIR}/%/bin/juju-metadata: PACKAGE = github.com/juju/juju/cmd/plugins/juju-metadata
 ${BUILD_DIR}/%/bin/juju-metadata: phony_explicit
 # build for juju-metadata
+	$(run_go_build)
+
+${BUILD_DIR}/%/bin/juju-complete: PACKAGE = github.com/juju/juju/cmd/juju-complete
+${BUILD_DIR}/%/bin/juju-complete: phony_explicit
+# build for juju-complete
 	$(run_go_build)
 
 ${BUILD_DIR}/%/bin/pebble: PACKAGE = github.com/canonical/pebble/cmd/pebble

--- a/cmd/juju-complete/main.go
+++ b/cmd/juju-complete/main.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	if err := run(os.Stdout, os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(output *os.File, args []string) error {
+	flags := flag.NewFlagSet("juju-complete", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+
+	var shell string
+	var position int
+	var dumpScript string
+	var ttl int
+
+	flags.StringVar(&shell, "shell", "bash", "completion shell")
+	flags.IntVar(&position, "position", -1, "cursor word index")
+	flags.StringVar(&dumpScript, "dump-script", "", "shell integration snippet")
+	flags.IntVar(&ttl, "ttl", 0, "cache ttl override in seconds")
+
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	message := describeInvocation(shell, position, dumpScript, ttl, flags.Args(), args)
+	_, err := fmt.Fprint(output, message)
+	return err
+}
+
+func describeInvocation(shell string, position int, dumpScript string, ttl int, words []string, rawArgs []string) string {
+	var builder strings.Builder
+	builder.WriteString("juju-complete debug input\n")
+	builder.WriteString(fmt.Sprintf("shell=%q\n", shell))
+	builder.WriteString(fmt.Sprintf("position=%d\n", position))
+	builder.WriteString(fmt.Sprintf("dump_script=%q\n", dumpScript))
+	builder.WriteString(fmt.Sprintf("ttl=%d\n", ttl))
+	builder.WriteString(fmt.Sprintf("raw_args=%q\n", rawArgs))
+	builder.WriteString(fmt.Sprintf("words=%q\n", words))
+	return builder.String()
+}

--- a/cmd/juju-complete/main_test.go
+++ b/cmd/juju-complete/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+)
+
+type mainSuite struct{}
+
+func TestMainSuite(t *testing.T) {
+	tc.Run(t, &mainSuite{})
+}
+
+func (s *mainSuite) TestDescribeInvocation(c *tc.C) {
+	got := describeInvocation("bash", 3, "", 120, []string{"juju", "status", "--model"}, []string{"--shell", "bash", "--", "juju", "status", "--model"})
+	want := "juju-complete debug input\n" +
+		"shell=\"bash\"\n" +
+		"position=3\n" +
+		"dump_script=\"\"\n" +
+		"ttl=120\n" +
+		"raw_args=[\"--shell\" \"bash\" \"--\" \"juju\" \"status\" \"--model\"]\n" +
+		"words=[\"juju\" \"status\" \"--model\"]\n"
+
+	c.Assert(got, tc.Equals, want)
+}

--- a/plan.md
+++ b/plan.md
@@ -76,6 +76,10 @@ bundling the binary and scripts into the snap.
 
 **Depends on Phase 2.**
 
+For the exploratory/debugging version, do not write tests. Keep the binary small and inspectable
+while the shell input shape is still being discovered. Validate manually by enabling completion
+and observing the debug output from real shell invocations.
+
 **3a — `tree.go`** — load `internal/completion/static.json` at binary init; no subprocess, no
 API connection.
 
@@ -141,6 +145,26 @@ _juju() {
 - `make install-completion` → install binary + both shell scripts
 - `make install-bash-completion`
 - `make install-zsh-completion`
+- Local exploratory targets:
+  - `make enable-zsh-completion` → install local `juju`/`juju-complete`, write
+    `${JUJU_DATA:-.juju}/zsh/site-functions/_juju`, then print the `fpath`/`compinit` command
+    needed to enable it in the current zsh session.
+  - `make enable-bash-completion` → install local `juju`/`juju-complete`, write
+    `${JUJU_DATA:-.juju}/bash_completion.d/juju`, then print the `source` command needed to
+    enable it in the current bash session.
+
+Local enablement examples:
+
+```zsh
+make enable-zsh-completion
+fpath=(${JUJU_DATA:-.juju}/zsh/site-functions $fpath)
+autoload -Uz compinit && compinit
+```
+
+```bash
+make enable-bash-completion
+source ${JUJU_DATA:-.juju}/bash_completion.d/juju
+```
 
 ### Phase 5 — Snap Support
 
@@ -182,8 +206,11 @@ Repeat Phase 1 script against `juju-complete`:
 
 ## Verification
 
-1. `go test ./cmd/juju-complete/... -race`
-2. `make pre-check` (golangci-lint + gci)
+Do not add or require new tests while the completion protocol is still exploratory. Prefer
+manual validation and benchmarks until the input/output contract is stable.
+
+1. `go build ./cmd/juju-complete`
+2. `make pre-check` (golangci-lint + gci) before submitting non-exploratory changes
 3. Manual bash: source bash script, tab-complete `juju dep<TAB>`, `juju deploy --<TAB>`,
    `juju ssh -m <TAB>`
 4. Manual zsh: `compinit`, same tests


### PR DESCRIPTION
# Description

Add make target for bash and zsh.

Run the make target, follow the instruction then do
`juju <tab>` and you should see

```
[11:09:15] ➜  juju git:(add-make-target) juju help completion
dump_script=                                           raw_args=\[--shell\ bash\ --position\ 1\ --\ juju\ \]  words=\[juju\ \]                                     
juju-complete\ debug\ input                            shell=bash                                                                                                  
position=1                                             ttl=0   
```