### PR TITLE
fix: models formatting and matching

### DIFF
--- a/cmd/juju/completion/backend.go
+++ b/cmd/juju/completion/backend.go
@@ -12,31 +12,27 @@ import (
 	apiclient "github.com/juju/juju/api/client/client"
 	"github.com/juju/juju/api/connector"
 	"github.com/juju/juju/api/jujuclient"
-	"github.com/juju/juju/cmd/modelcmd"
 	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/rpc/params"
 )
 
-type currentControllerFunc func(jujuclient.ClientStore) (string, error)
 type currentModelFunc func(jujuclient.ClientStore) (string, error)
 type statusFetcherFunc func(jujuclient.ClientStore, string) (*params.FullStatus, error)
 
 // Backend serves shell completion candidates backed by Juju client state.
 type Backend struct {
-	Store             jujuclient.ClientStore
-	currentController currentControllerFunc
-	currentModel      currentModelFunc
-	statusFetcher     statusFetcherFunc
+	Store         jujuclient.ClientStore
+	currentModel  currentModelFunc
+	statusFetcher statusFetcherFunc
 }
 
 // NewBackend returns a completion backend using the local Juju client store.
 func NewBackend() *Backend {
 	return &Backend{
-		Store:             jujuclient.NewFileClientStore(),
-		currentController: modelcmd.DetermineCurrentController,
-		currentModel:      determineCurrentModel,
-		statusFetcher:     fetchStatus,
+		Store:         jujuclient.NewFileClientStore(),
+		currentModel:  determineCurrentModel,
+		statusFetcher: fetchStatus,
 	}
 }
 
@@ -55,13 +51,8 @@ func (b *Backend) Controllers() ([]string, error) {
 }
 
 // Models returns model names suitable for `--model` completion.
-// It emits `controller:model` for all known controllers, and bare model names
-// for the current controller to match existing shell behavior.
+// Every model is emitted as `controller:model` for consistency.
 func (b *Backend) Models() ([]string, error) {
-	currentController, err := b.currentController(b.Store)
-	if err != nil {
-		return nil, err
-	}
 	controllers, err := b.Controllers()
 	if err != nil {
 		return nil, err
@@ -76,12 +67,8 @@ func (b *Backend) Models() ([]string, error) {
 			}
 			return nil, err
 		}
-		modelNames := mapKeys(models)
-		for _, modelName := range modelNames {
+		for _, modelName := range mapKeys(models) {
 			result = append(result, controllerName+":"+modelName)
-		}
-		if controllerName == currentController {
-			result = append(result, modelNames...)
 		}
 	}
 	sort.Strings(result)

--- a/cmd/juju/completion/backend_test.go
+++ b/cmd/juju/completion/backend_test.go
@@ -12,7 +12,7 @@ func TestControllersReturnsSortedNames(t *testing.T) {
 	store.Controllers["zeta"] = jujuclient.ControllerDetails{}
 	store.Controllers["alpha"] = jujuclient.ControllerDetails{}
 
-	backend := &Backend{Store: store, currentController: defaultCurrentController, currentModel: unreachableCurrentModel, statusFetcher: unreachableStatusFetcher}
+	backend := &Backend{Store: store, currentModel: unreachableCurrentModel, statusFetcher: unreachableStatusFetcher}
 	controllers, err := backend.Controllers()
 	if err != nil {
 		t.Fatalf("listing controllers: %v", err)
@@ -20,11 +20,10 @@ func TestControllersReturnsSortedNames(t *testing.T) {
 	assertEqualStrings(t, controllers, []string{"alpha", "zeta"})
 }
 
-func TestModelsReturnsControllerQualifiedAndBareCurrentModels(t *testing.T) {
+func TestModelsReturnsControllerQualifiedModels(t *testing.T) {
 	store := jujuclient.NewMemStore()
 	store.Controllers["alpha"] = jujuclient.ControllerDetails{}
 	store.Controllers["beta"] = jujuclient.ControllerDetails{}
-	store.CurrentControllerName = "alpha"
 	store.Models["alpha"] = &jujuclient.ControllerModels{
 		Models: map[string]jujuclient.ModelDetails{
 			"admin/first":  {},
@@ -38,14 +37,12 @@ func TestModelsReturnsControllerQualifiedAndBareCurrentModels(t *testing.T) {
 		},
 	}
 
-	backend := &Backend{Store: store, currentController: defaultCurrentController, currentModel: unreachableCurrentModel, statusFetcher: unreachableStatusFetcher}
+	backend := &Backend{Store: store, currentModel: unreachableCurrentModel, statusFetcher: unreachableStatusFetcher}
 	models, err := backend.Models()
 	if err != nil {
 		t.Fatalf("listing models: %v", err)
 	}
 	assertEqualStrings(t, models, []string{
-		"admin/first",
-		"admin/second",
 		"alpha:admin/first",
 		"alpha:admin/second",
 		"beta:admin/other",
@@ -65,9 +62,8 @@ func TestApplicationsUnitsAndMachinesUseResolvedModel(t *testing.T) {
 	}
 
 	backend := &Backend{
-		Store:             store,
-		currentController: defaultCurrentController,
-		currentModel:      func(_ jujuclient.ClientStore) (string, error) { return "alpha:first", nil },
+		Store:        store,
+		currentModel: func(_ jujuclient.ClientStore) (string, error) { return "alpha:first", nil },
 		statusFetcher: func(_ jujuclient.ClientStore, modelIdentifier string) (*params.FullStatus, error) {
 			if modelIdentifier != "alpha:first" {
 				t.Fatalf("unexpected model resolution: %s", modelIdentifier)
@@ -115,9 +111,8 @@ func TestApplicationsUnitsAndMachinesUseResolvedModel(t *testing.T) {
 
 func TestApplicationsPassExplicitModelThrough(t *testing.T) {
 	backend := &Backend{
-		Store:             jujuclient.NewMemStore(),
-		currentController: defaultCurrentController,
-		currentModel:      unreachableCurrentModel,
+		Store:        jujuclient.NewMemStore(),
+		currentModel: unreachableCurrentModel,
 		statusFetcher: func(_ jujuclient.ClientStore, modelIdentifier string) (*params.FullStatus, error) {
 			if modelIdentifier != "test-36:admin/example" {
 				t.Fatalf("unexpected explicit model identifier: %s", modelIdentifier)
@@ -143,10 +138,6 @@ func assertEqualStrings(t *testing.T, got, want []string) {
 			t.Fatalf("unexpected values: got %v want %v", got, want)
 		}
 	}
-}
-
-func defaultCurrentController(store jujuclient.ClientStore) (string, error) {
-	return store.CurrentController()
 }
 
 func unreachableCurrentModel(_ jujuclient.ClientStore) (string, error) {

--- a/cmd/juju/completion/complete.go
+++ b/cmd/juju/completion/complete.go
@@ -155,7 +155,7 @@ func filterCandidates(candidates []string, current string) []string {
 	}
 	filtered := make([]string, 0, len(candidates))
 	for _, candidate := range candidates {
-		if strings.HasPrefix(candidate, current) {
+		if strings.Contains(candidate, current) {
 			filtered = append(filtered, candidate)
 		}
 	}

--- a/cmd/juju/completion/complete_test.go
+++ b/cmd/juju/completion/complete_test.go
@@ -9,10 +9,9 @@ import (
 
 func TestCompleteHelpReturnsCommands(t *testing.T) {
 	backend := &Backend{
-		Store:             jujuclient.NewMemStore(),
-		currentController: defaultCurrentController,
-		currentModel:      unreachableCurrentModel,
-		statusFetcher:     unreachableStatusFetcher,
+		Store:         jujuclient.NewMemStore(),
+		currentModel:  unreachableCurrentModel,
+		statusFetcher: unreachableStatusFetcher,
 	}
 
 	candidates, err := backend.Complete(testSnapshot(), Request{
@@ -33,10 +32,9 @@ func TestCompleteHelpReturnsCommands(t *testing.T) {
 
 func TestCompleteFlagsForCommand(t *testing.T) {
 	backend := &Backend{
-		Store:             jujuclient.NewMemStore(),
-		currentController: defaultCurrentController,
-		currentModel:      unreachableCurrentModel,
-		statusFetcher:     unreachableStatusFetcher,
+		Store:         jujuclient.NewMemStore(),
+		currentModel:  unreachableCurrentModel,
+		statusFetcher: unreachableStatusFetcher,
 	}
 
 	candidates, err := backend.Complete(testSnapshot(), Request{
@@ -52,9 +50,8 @@ func TestCompleteFlagsForCommand(t *testing.T) {
 
 func TestCompleteApplicationsFromCommandPosition(t *testing.T) {
 	backend := &Backend{
-		Store:             jujuclient.NewMemStore(),
-		currentController: defaultCurrentController,
-		currentModel:      func(_ jujuclient.ClientStore) (string, error) { return "test-36:admin/example", nil },
+		Store:        jujuclient.NewMemStore(),
+		currentModel: func(_ jujuclient.ClientStore) (string, error) { return "test-36:admin/example", nil },
 		statusFetcher: func(_ jujuclient.ClientStore, modelIdentifier string) (*params.FullStatus, error) {
 			if modelIdentifier != "test-36:admin/example" {
 				t.Fatalf("unexpected model identifier: %s", modelIdentifier)
@@ -81,7 +78,6 @@ func TestCompleteSwitchMergesControllersAndModels(t *testing.T) {
 	store := jujuclient.NewMemStore()
 	store.Controllers["test-36"] = jujuclient.ControllerDetails{}
 	store.Controllers["other"] = jujuclient.ControllerDetails{}
-	store.CurrentControllerName = "test-36"
 	store.Models["test-36"] = &jujuclient.ControllerModels{
 		Models: map[string]jujuclient.ModelDetails{
 			"admin/example": {},
@@ -89,10 +85,9 @@ func TestCompleteSwitchMergesControllersAndModels(t *testing.T) {
 	}
 
 	backend := &Backend{
-		Store:             store,
-		currentController: defaultCurrentController,
-		currentModel:      unreachableCurrentModel,
-		statusFetcher:     unreachableStatusFetcher,
+		Store:         store,
+		currentModel:  unreachableCurrentModel,
+		statusFetcher: unreachableStatusFetcher,
 	}
 
 	candidates, err := backend.Complete(testSnapshot(), Request{

--- a/etc/zsh/completions/_juju
+++ b/etc/zsh/completions/_juju
@@ -14,7 +14,7 @@ _juju() {
     done
 
     comps=(${(f)"$(${words[1]} "${args[@]}" 2>/dev/null)"})
-    _describe 'juju' comps
+    compadd -a comps
 }
 
 if (( $+functions[compdef] )); then


### PR DESCRIPTION
# Description

models are shown in a consistent format: <controller>:<owner>/<model>, and support `strings.Contains` match.