### PR TITLE
feat: don't hardcode the positionals and instead declare them in meta…

### DIFF
--- a/cmd/juju/completion/complete.go
+++ b/cmd/juju/completion/complete.go
@@ -26,46 +26,24 @@ func (b *Backend) Complete(snapshot Snapshot, request Request) ([]string, error)
 	action := request.action()
 	previous := request.word(request.Cword - 1)
 	model := request.model()
+	command, hasCommand := snapshot.Lookup(action)
+	previousFlagCompletion := completionForFlag(command, previous)
 
 	switch {
 	case request.Cword <= 1:
 		return filterCandidates(snapshot.CommandNames(), current), nil
 	case action == "help":
 		return filterCandidates(snapshot.CommandNames(), current), nil
-	case previous == "--controller" || previous == "-c":
-		controllers, err := b.Controllers()
+	case previousFlagCompletion != "":
+		candidates, err := b.candidatesForTargets(model, []string{previousFlagCompletion})
 		if err != nil {
 			return nil, err
 		}
-		return filterCandidates(controllers, current), nil
-	case previous == "--model" || previous == "-m":
-		models, err := b.Models()
-		if err != nil {
-			return nil, err
-		}
-		return filterCandidates(models, current), nil
-	case previous == "--application":
-		applications, err := b.Applications(model)
-		if err != nil {
-			return nil, err
-		}
-		return filterCandidates(applications, current), nil
-	case previous == "--unit":
-		units, err := b.Units(model, "")
-		if err != nil {
-			return nil, err
-		}
-		return filterCandidates(units, current), nil
-	case previous == "--machine":
-		machines, err := b.Machines(model)
-		if err != nil {
-			return nil, err
-		}
-		return filterCandidates(machines, current), nil
-	case strings.HasPrefix(current, "-") && action != "":
+		return filterCandidates(candidates, current), nil
+	case strings.HasPrefix(current, "-") && hasCommand:
 		return filterCandidates(snapshot.FlagsFor(action), current), nil
 	default:
-		candidates, err := b.completePositional(action, model)
+		candidates, err := b.completePositional(command, request.positionalIndex(command), model)
 		if err != nil {
 			return nil, err
 		}
@@ -73,21 +51,39 @@ func (b *Backend) Complete(snapshot Snapshot, request Request) ([]string, error)
 	}
 }
 
-func (b *Backend) completePositional(action, model string) ([]string, error) {
-	switch action {
-	case "switch":
-		controllers, err := b.Controllers()
+func (b *Backend) completePositional(command Command, index int, model string) ([]string, error) {
+	for _, positional := range command.Positionals {
+		if positional.Index != index && !(positional.Repeat && index >= positional.Index) {
+			continue
+		}
+		return b.candidatesForTargets(model, positional.Targets)
+	}
+	return nil, nil
+}
+
+func (b *Backend) candidatesForTargets(model string, targets []string) ([]string, error) {
+	groups := make([][]string, 0, len(targets))
+	for _, target := range targets {
+		candidates, err := b.candidatesForTarget(model, target)
 		if err != nil {
 			return nil, err
 		}
-		models, err := b.Models()
-		if err != nil {
-			return nil, err
-		}
-		return mergeCandidates(controllers, models), nil
-	case "config", "refresh", "expose", "unexpose", "remove-application", "application-storage", "constraints", "set-constraints", "set-application-base":
+		groups = append(groups, candidates)
+	}
+	return mergeCandidates(groups...), nil
+}
+
+func (b *Backend) candidatesForTarget(model, target string) ([]string, error) {
+	switch target {
+	case CompletionApplications:
 		return b.Applications(model)
-	case "status":
+	case CompletionControllers:
+		return b.Controllers()
+	case CompletionMachines:
+		return b.Machines(model)
+	case CompletionModels:
+		return b.Models()
+	case CompletionStatusTargets:
 		applications, err := b.Applications(model)
 		if err != nil {
 			return nil, err
@@ -97,7 +93,7 @@ func (b *Backend) completePositional(action, model string) ([]string, error) {
 			return nil, err
 		}
 		return mergeCandidates(applications, units), nil
-	case "ssh", "scp", "debug-hooks", "debug-code":
+	case CompletionSSHTargets:
 		units, err := b.Units(model, "")
 		if err != nil {
 			return nil, err
@@ -107,10 +103,16 @@ func (b *Backend) completePositional(action, model string) ([]string, error) {
 			return nil, err
 		}
 		return mergeCandidates(units, machines), nil
-	case "resolved", "remove-unit":
-		return b.Units(model, "")
-	case "show-machine", "remove-machine", "upgrade-machine":
-		return b.Machines(model)
+	case CompletionSwitchTargets:
+		controllers, err := b.Controllers()
+		if err != nil {
+			return nil, err
+		}
+		models, err := b.Models()
+		if err != nil {
+			return nil, err
+		}
+		return mergeCandidates(controllers, models), nil
 	default:
 		return nil, nil
 	}
@@ -147,6 +149,68 @@ func (r Request) model() string {
 		}
 	}
 	return ""
+}
+
+func (r Request) positionalIndex(command Command) int {
+	index := 0
+	for i := 2; i < r.Cword && i < len(r.Words); i++ {
+		token := r.Words[i]
+		if strings.HasPrefix(token, "-") {
+			if flagConsumesValue(command, token) && i+1 < r.Cword {
+				i++
+			}
+			continue
+		}
+		index++
+	}
+	return index
+}
+
+func completionForFlag(command Command, token string) string {
+	name := flagName(token)
+	if name == "" {
+		return ""
+	}
+	switch token {
+	case "-c":
+		return CompletionControllers
+	case "-m":
+		return CompletionModels
+	}
+	for _, flag := range command.Flags {
+		if flag.Name == name {
+			return flag.ValueCompletion
+		}
+	}
+	return flagValueCompletion(name)
+}
+
+func flagConsumesValue(command Command, token string) bool {
+	name := flagName(token)
+	if name == "" || strings.Contains(token, "=") {
+		return false
+	}
+	for _, flag := range command.Flags {
+		if flag.Name == name {
+			return !flag.IsBoolean
+		}
+	}
+	return token == "-c" || token == "-m" || strings.HasPrefix(token, "--")
+}
+
+func flagName(token string) string {
+	switch {
+	case strings.HasPrefix(token, "--"):
+		name := strings.TrimPrefix(token, "--")
+		if idx := strings.Index(name, "="); idx >= 0 {
+			name = name[:idx]
+		}
+		return name
+	case strings.HasPrefix(token, "-") && len(token) == 2:
+		return strings.TrimPrefix(token, "-")
+	default:
+		return ""
+	}
 }
 
 func filterCandidates(candidates []string, current string) []string {

--- a/cmd/juju/completion/complete_test.go
+++ b/cmd/juju/completion/complete_test.go
@@ -47,7 +47,7 @@ func TestCompleteFlagsForCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("completing flags: %v", err)
 	}
-	assertEqualStrings(t, candidates, []string{"--channel", "--config", "--constraints"})
+	assertEqualStrings(t, candidates, []string{"--channel", "--config", "--constraints", "--controller"})
 }
 
 func TestCompleteApplicationsFromCommandPosition(t *testing.T) {
@@ -75,6 +75,29 @@ func TestCompleteApplicationsFromCommandPosition(t *testing.T) {
 		t.Fatalf("completing applications: %v", err)
 	}
 	assertEqualStrings(t, candidates, []string{"backend"})
+}
+
+func TestCompleteFlagValuesFromMetadata(t *testing.T) {
+	store := jujuclient.NewMemStore()
+	store.Controllers["test-36"] = jujuclient.ControllerDetails{}
+	store.Controllers["other"] = jujuclient.ControllerDetails{}
+
+	backend := &Backend{
+		Store:             store,
+		currentController: defaultCurrentController,
+		currentModel:      unreachableCurrentModel,
+		statusFetcher:     unreachableStatusFetcher,
+	}
+
+	candidates, err := backend.Complete(testSnapshot(), Request{
+		Words:   []string{"juju", "deploy", "--controller", "te"},
+		Cword:   3,
+		Current: "te",
+	})
+	if err != nil {
+		t.Fatalf("completing controller flag value: %v", err)
+	}
+	assertEqualStrings(t, candidates, []string{"test-36"})
 }
 
 func TestCompleteSwitchMergesControllersAndModels(t *testing.T) {
@@ -108,9 +131,22 @@ func TestCompleteSwitchMergesControllersAndModels(t *testing.T) {
 
 func testSnapshot() Snapshot {
 	return Snapshot{Commands: []Command{
-		{Name: "config"},
+		{Name: "config", Positionals: []PositionalCompletion{{
+			Index:   0,
+			Targets: []string{CompletionApplications},
+			Repeat:  true,
+		}}},
 		{Name: "controllers"},
-		{Name: "deploy", Flags: []Flag{{Name: "channel"}, {Name: "config"}, {Name: "constraints"}}},
-		{Name: "switch"},
+		{Name: "deploy", Flags: []Flag{
+			{Name: "channel"},
+			{Name: "config"},
+			{Name: "constraints"},
+			{Name: "controller", ValueCompletion: CompletionControllers},
+		}},
+		{Name: "switch", Positionals: []PositionalCompletion{{
+			Index:   0,
+			Targets: []string{CompletionSwitchTargets},
+			Repeat:  true,
+		}}},
 	}}
 }

--- a/cmd/juju/completion/metadata.go
+++ b/cmd/juju/completion/metadata.go
@@ -16,19 +16,28 @@ type Snapshot struct {
 
 // Command describes a single Juju command and its flags.
 type Command struct {
-	Name    string   `json:"name"`
-	Aliases []string `json:"aliases,omitempty"`
-	Args    string   `json:"args,omitempty"`
-	Purpose string   `json:"purpose,omitempty"`
-	Flags   []Flag   `json:"flags,omitempty"`
+	Name        string                 `json:"name"`
+	Aliases     []string               `json:"aliases,omitempty"`
+	Args        string                 `json:"args,omitempty"`
+	Purpose     string                 `json:"purpose,omitempty"`
+	Flags       []Flag                 `json:"flags,omitempty"`
+	Positionals []PositionalCompletion `json:"positionals,omitempty"`
 }
 
 // Flag describes a command-line flag that can be completed.
 type Flag struct {
-	Name      string `json:"name"`
-	Usage     string `json:"usage,omitempty"`
-	Default   string `json:"default,omitempty"`
-	IsBoolean bool   `json:"isBoolean,omitempty"`
+	Name            string `json:"name"`
+	Usage           string `json:"usage,omitempty"`
+	Default         string `json:"default,omitempty"`
+	IsBoolean       bool   `json:"isBoolean,omitempty"`
+	ValueCompletion string `json:"valueCompletion,omitempty"`
+}
+
+// PositionalCompletion describes how to complete a command positional argument.
+type PositionalCompletion struct {
+	Index   int      `json:"index"`
+	Targets []string `json:"targets,omitempty"`
+	Repeat  bool     `json:"repeat,omitempty"`
 }
 
 // Registry records Juju commands as they are registered.
@@ -118,11 +127,12 @@ func (r *registry) RegisterDeprecated(command cmd.Command, check cmd.Deprecation
 func describeCommand(command cmd.Command) Command {
 	info := command.Info()
 	return Command{
-		Name:    info.Name,
-		Aliases: append([]string(nil), info.Aliases...),
-		Args:    info.Args,
-		Purpose: info.Purpose,
-		Flags:   describeFlags(command, info.Name),
+		Name:        info.Name,
+		Aliases:     append([]string(nil), info.Aliases...),
+		Args:        info.Args,
+		Purpose:     info.Purpose,
+		Flags:       describeFlags(command, info.Name),
+		Positionals: positionalCompletions(info.Name),
 	}
 }
 
@@ -135,13 +145,81 @@ func describeFlags(command cmd.Command, name string) []Flag {
 	flagSet.VisitAll(func(flag *gnuflag.Flag) {
 		_, isBool := flag.Value.(boolFlag)
 		flags = append(flags, Flag{
-			Name:      flag.Name,
-			Usage:     flag.Usage,
-			Default:   flag.DefValue,
-			IsBoolean: isBool,
+			Name:            flag.Name,
+			Usage:           flag.Usage,
+			Default:         flag.DefValue,
+			IsBoolean:       isBool,
+			ValueCompletion: flagValueCompletion(flag.Name),
 		})
 	})
 	return flags
 }
 
 var _ Registry = (*registry)(nil)
+
+const (
+	CompletionApplications  = "applications"
+	CompletionControllers   = "controllers"
+	CompletionMachines      = "machines"
+	CompletionModels        = "models"
+	CompletionStatusTargets = "status-targets"
+	CompletionUnits         = "units"
+	CompletionSSHTargets    = "ssh-targets"
+	CompletionSwitchTargets = "switch-targets"
+)
+
+var positionalCompletionByCommand = map[string][]PositionalCompletion{
+	"application-storage":  repeatedPositionals(CompletionApplications),
+	"config":               repeatedPositionals(CompletionApplications),
+	"constraints":          repeatedPositionals(CompletionApplications),
+	"debug-code":           repeatedPositionals(CompletionSSHTargets),
+	"debug-hooks":          repeatedPositionals(CompletionSSHTargets),
+	"expose":               repeatedPositionals(CompletionApplications),
+	"refresh":              repeatedPositionals(CompletionApplications),
+	"remove-application":   repeatedPositionals(CompletionApplications),
+	"remove-machine":       repeatedPositionals(CompletionMachines),
+	"remove-unit":          repeatedPositionals(CompletionUnits),
+	"resolved":             repeatedPositionals(CompletionUnits),
+	"scp":                  repeatedPositionals(CompletionSSHTargets),
+	"set-application-base": repeatedPositionals(CompletionApplications),
+	"set-constraints":      repeatedPositionals(CompletionApplications),
+	"show-machine":         repeatedPositionals(CompletionMachines),
+	"ssh":                  repeatedPositionals(CompletionSSHTargets),
+	"status":               repeatedPositionals(CompletionStatusTargets),
+	"switch":               repeatedPositionals(CompletionSwitchTargets),
+	"unexpose":             repeatedPositionals(CompletionApplications),
+	"upgrade-machine":      repeatedPositionals(CompletionMachines),
+}
+
+func positionalCompletions(commandName string) []PositionalCompletion {
+	completions := positionalCompletionByCommand[commandName]
+	if len(completions) == 0 {
+		return nil
+	}
+	return append([]PositionalCompletion(nil), completions...)
+}
+
+func repeatedPositionals(targets ...string) []PositionalCompletion {
+	return []PositionalCompletion{{
+		Index:   0,
+		Targets: append([]string(nil), targets...),
+		Repeat:  true,
+	}}
+}
+
+func flagValueCompletion(name string) string {
+	switch name {
+	case "application":
+		return CompletionApplications
+	case "controller":
+		return CompletionControllers
+	case "machine":
+		return CompletionMachines
+	case "model":
+		return CompletionModels
+	case "unit":
+		return CompletionUnits
+	default:
+		return ""
+	}
+}

--- a/cmd/juju/completion/metadata_test.go
+++ b/cmd/juju/completion/metadata_test.go
@@ -61,6 +61,34 @@ func TestFlagsForResolvesAliases(t *testing.T) {
 	}
 }
 
+func TestDescribeIncludesCompletionMetadata(t *testing.T) {
+	snapshot := describeSnapshot()
+
+	deploy, found := findCommand(snapshot, "deploy")
+	if !found {
+		t.Fatalf("deploy command not found")
+	}
+	if flag, found := findFlag(deploy, "model"); !found {
+		t.Fatalf("deploy flag %q not found", "model")
+	} else if flag.ValueCompletion != completion.CompletionModels {
+		t.Fatalf("unexpected model flag completion: %q", flag.ValueCompletion)
+	}
+
+	status, found := findCommand(snapshot, "status")
+	if !found {
+		t.Fatalf("status command not found")
+	}
+	if len(status.Positionals) != 1 {
+		t.Fatalf("unexpected status positionals: %#v", status.Positionals)
+	}
+	if !status.Positionals[0].Repeat {
+		t.Fatalf("expected status positional completion to repeat")
+	}
+	if !contains(status.Positionals[0].Targets, completion.CompletionStatusTargets) {
+		t.Fatalf("expected status positional targets to include %q: %#v", completion.CompletionStatusTargets, status.Positionals[0].Targets)
+	}
+}
+
 func findCommand(snapshot completion.Snapshot, name string) (completion.Command, bool) {
 	for _, command := range snapshot.Commands {
 		if command.Name == name {


### PR DESCRIPTION
Summary

This PR moves Juju completion behavior toward metadata-driven rules.

It adds completion metadata to command snapshots so commands can describe what their positional arguments complete, and flags can describe what kind of values they accept. The completion engine now reads that metadata instead of relying only on hard-coded command-name logic.

User-facing behavior is intended to stay the same, but the implementation is easier to extend for future completion improvements.


